### PR TITLE
ARQ-913 - make the log threshold configurable

### DIFF
--- a/jbossas-managed-6/src/main/java/org/jboss/arquillian/container/jbossas/managed_6/JBossASConfiguration.java
+++ b/jbossas-managed-6/src/main/java/org/jboss/arquillian/container/jbossas/managed_6/JBossASConfiguration.java
@@ -51,6 +51,8 @@ public class JBossASConfiguration implements ContainerConfiguration
    private String javaHome = System.getenv("JAVA_HOME");
    
    private String javaVmArguments = "-Xmx512m -XX:MaxPermSize=128m";
+
+   private String logThreshold = "INFO";
    
    private int startupTimeoutInSeconds = 120;
 
@@ -244,6 +246,16 @@ public class JBossASConfiguration implements ContainerConfiguration
    public String getJavaVmArguments()
    {
       return javaVmArguments;
+   }
+
+   public String getLogThreshold()
+   {
+      return logThreshold;
+   }
+
+   public void setLogThreshold(String logThreshold)
+   {
+      this.logThreshold = logThreshold;
    }
    
    /**

--- a/jbossas-managed-6/src/main/java/org/jboss/arquillian/container/jbossas/managed_6/JBossASLocalContainer.java
+++ b/jbossas-managed-6/src/main/java/org/jboss/arquillian/container/jbossas/managed_6/JBossASLocalContainer.java
@@ -103,7 +103,7 @@ public class JBossASLocalContainer implements DeployableContainer<JBossASConfigu
             throw new LifecycleException(
             		"The server is already running! " +
             		"Managed containers does not support connecting to running server instances due to the " +
-            		"possible harmfull effect of connecting to the wrong server. Please stop server before running or " +
+            		"possible harmful effect of connecting to the wrong server. Please stop server before running or " +
             		"change to another type of container.");
          }
          
@@ -305,6 +305,7 @@ public class JBossASLocalContainer implements DeployableContainer<JBossASConfigu
       server.setRmiPort(rmiPort());
       server.setHost(configuration.getBindAddress());
       server.setHasWebServer(!configuration.isUseRmiPortForAliveCheck());
+      server.setLogThreshold(configuration.getLogThreshold());
       
       server.setUsername("admin");
       server.setPassword("admin");


### PR DESCRIPTION
Add a configuration property for the log threshold with a default value of "INFO". Pass this value to the Server instance, which assigns it as a system property in the start command.
